### PR TITLE
Throwing a System.InvalidOperationException

### DIFF
--- a/content/Api/Blip.Api.Template/Middleware/ErrorHandlingMiddleware.cs
+++ b/content/Api/Blip.Api.Template/Middleware/ErrorHandlingMiddleware.cs
@@ -65,7 +65,7 @@ namespace Blip.Api.Template.Middleware
             string body = string.Empty;
             using (var reader = new StreamReader(context.Request.Body))
             {
-                body = reader.ReadToEnd();
+                body = await reader.ReadToEndAsync();
             }
 
             _logger.Error(exception, "[traceId:{@traceId}]{@user} Error. Headers: {@headers}. Query: {@query}. Path: {@path}. Body: {@body}",


### PR DESCRIPTION
This line is trhowing a System.InvalidOperationException.

Ex:
System.InvalidOperationException: Synchronous operations are disallowed. Call ReadAsync or set AllowSynchronousIO to true instead. 

To fix this error I changed the ReadToEnd to ReadToEndAsync and adding  await. =)