### PR TITLE
refactor: Move duplicated logic up to superclass

### DIFF
--- a/content/Api/Blip.Api.Template.Facades/Strategies/ExceptionHandlingStrategies/ApiExceptionHandlingStrategy.cs
+++ b/content/Api/Blip.Api.Template.Facades/Strategies/ExceptionHandlingStrategies/ApiExceptionHandlingStrategy.cs
@@ -1,28 +1,27 @@
 using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
-using Serilog;
+
 using RestEase;
-using Blip.Api.Template.Models;
+
+using Serilog;
 
 namespace Blip.Api.Template.Facades.Strategies.ExceptionHandlingStrategies
 {
     public class ApiExceptionHandlingStrategy : ExceptionHandlingStrategy
     {
-        private readonly ILogger _logger;
+        #region Public Constructors
 
-        public ApiExceptionHandlingStrategy(ILogger logger)
-        {
-            _logger = logger;
-        }
+        public ApiExceptionHandlingStrategy(ILogger logger) : base(logger) { }
 
-        public override async Task<HttpContext> HandleAsync(HttpContext context, Exception exception)
+        #endregion Public Constructors
+
+        #region Internal Methods
+
+        internal override int GetStatusCode(Exception exception)
         {
             var apiException = exception as ApiException;
-            _logger.Error(apiException, "[{@user}] Error: {@exception}", context.Request.Headers[Constants.BLIP_USER_HEADER], apiException.Message);
-            context.Response.StatusCode = (int)apiException.StatusCode;
-
-            return await Task.FromResult(context);
+            return (int)apiException.StatusCode;
         }
+
+        #endregion Internal Methods
     }
 }

--- a/content/Api/Blip.Api.Template.Facades/Strategies/ExceptionHandlingStrategies/ExceptionHandlingStrategy.cs
+++ b/content/Api/Blip.Api.Template.Facades/Strategies/ExceptionHandlingStrategies/ExceptionHandlingStrategy.cs
@@ -28,7 +28,7 @@ namespace Blip.Api.Template.Facades.Strategies.ExceptionHandlingStrategies
 
         #region Public Methods
 
-        public async Task<HttpContext> HandleAsync(HttpContext context, Exception exception)
+        public virtual async Task<HttpContext> HandleAsync(HttpContext context, Exception exception)
         {
             _logger.Error(exception, "[{@user}] Error: {@exception}", context.Request.Headers[Constants.BLIP_USER_HEADER], exception.Message);
             context.Response.StatusCode = GetStatusCode(exception);

--- a/content/Api/Blip.Api.Template.Facades/Strategies/ExceptionHandlingStrategies/ExceptionHandlingStrategy.cs
+++ b/content/Api/Blip.Api.Template.Facades/Strategies/ExceptionHandlingStrategies/ExceptionHandlingStrategy.cs
@@ -1,11 +1,47 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Http;
+
+using Serilog;
+
+using Blip.Api.Template.Models;
 
 namespace Blip.Api.Template.Facades.Strategies.ExceptionHandlingStrategies
 {
     public abstract class ExceptionHandlingStrategy
     {
-        public abstract Task<HttpContext> HandleAsync(HttpContext context, Exception exception);
+        #region Private Fields
+
+        private readonly ILogger _logger;
+
+        #endregion Private Fields
+
+        #region Public Constructors
+
+        public ExceptionHandlingStrategy(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        #endregion Public Constructors
+
+        #region Public Methods
+
+        public async Task<HttpContext> HandleAsync(HttpContext context, Exception exception)
+        {
+            _logger.Error(exception, "[{@user}] Error: {@exception}", context.Request.Headers[Constants.BLIP_USER_HEADER], exception.Message);
+            context.Response.StatusCode = GetStatusCode(exception);
+
+            return await Task.FromResult(context);
+        }
+
+        #endregion Public Methods
+
+        #region Internal Methods
+
+        internal abstract int GetStatusCode(Exception exception);
+
+        #endregion Internal Methods
     }
 }

--- a/content/Api/Blip.Api.Template.Facades/Strategies/ExceptionHandlingStrategies/ExceptionHandlingStrategy.cs
+++ b/content/Api/Blip.Api.Template.Facades/Strategies/ExceptionHandlingStrategies/ExceptionHandlingStrategy.cs
@@ -19,7 +19,7 @@ namespace Blip.Api.Template.Facades.Strategies.ExceptionHandlingStrategies
 
         #region Public Constructors
 
-        public ExceptionHandlingStrategy(ILogger logger)
+        protected ExceptionHandlingStrategy(ILogger logger)
         {
             _logger = logger;
         }

--- a/content/Api/Blip.Api.Template.Facades/Strategies/ExceptionHandlingStrategies/NotImplementedExceptionHandlingStrategy.cs
+++ b/content/Api/Blip.Api.Template.Facades/Strategies/ExceptionHandlingStrategies/NotImplementedExceptionHandlingStrategy.cs
@@ -1,28 +1,23 @@
 using System;
-using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Http;
+
 using Serilog;
-using RestEase;
-using Blip.Api.Template.Models;
 
 namespace Blip.Api.Template.Facades.Strategies.ExceptionHandlingStrategies
 {
     public class NotImplementedExceptionHandlingStrategy : ExceptionHandlingStrategy
     {
-        private readonly ILogger _logger;
+        #region Public Constructors
 
-        public NotImplementedExceptionHandlingStrategy(ILogger logger)
-        {
-            _logger = logger;
-        }
+        public NotImplementedExceptionHandlingStrategy(ILogger logger) : base(logger) { }
 
-        public override async Task<HttpContext> HandleAsync(HttpContext context, Exception exception)
-        {
-            var notImplementeException = exception as NotImplementedException;
-            _logger.Error(notImplementeException, "[{@user}] Error: {@exception}", context.Request.Headers[Constants.BLIP_USER_HEADER], notImplementeException.Message);
-            context.Response.StatusCode = StatusCodes.Status501NotImplemented;
+        #endregion Public Constructors
 
-            return await Task.FromResult(context);
-        }
+        #region Internal Methods
+
+        internal override int GetStatusCode(Exception exception) => StatusCodes.Status501NotImplemented;
+
+        #endregion Internal Methods
     }
 }


### PR DESCRIPTION
The HandleAsync method was pretty much the same for all strategies. This PR moves the duplicated logic up to the superclass and creates an abstract method for the part that differs the strategies: the way they get the Status Code.