### PR TITLE
Settings to use health check

### DIFF
--- a/content/Api/Blip.Api.Template/Blip.Api.Template.csproj
+++ b/content/Api/Blip.Api.Template/Blip.Api.Template.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="3.0.9" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="3.0.2" />
     <PackageReference Include="Blip.HttpClient" Version="1.0.5" />
-    <PackageReference Include="Lime.Protocol" Version="0.8.111-beta" />
+    <PackageReference Include="Lime.Protocol" Version="0.9.11-beta" />
     <PackageReference Include="Lime.Protocol.Serialization" Version="0.7.278" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Kubernetes.Tools.Targets" Version="1.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RestEase" Version="1.4.10" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
@@ -55,7 +55,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.0.0-rc2" />
     <PackageReference Include="Take.Api.Health.Eir" Version="1.0.1" />
     <PackageReference Include="Take.Api.Security.Heimdall" Version="1.0.0" />
-    <PackageReference Include="Take.Blip.Client" Version="0.5.186" />
+    <PackageReference Include="Take.Blip.Client" Version="0.5.285" />
   </ItemGroup>
 
   <ItemGroup>

--- a/content/Api/Blip.Api.Template/Properties/launchSettings.json
+++ b/content/Api/Blip.Api.Template/Properties/launchSettings.json
@@ -18,7 +18,7 @@
     "Blip.Api.Template": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "api/health",
+      "launchUrl": "health",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/content/Api/Blip.Api.Template/Startup.cs
+++ b/content/Api/Blip.Api.Template/Startup.cs
@@ -6,25 +6,29 @@ using Blip.Api.Template.Facades.Extensions;
 using Blip.Api.Template.Middleware;
 using Blip.Api.Template.Models;
 using Blip.Api.Template.Models.UI;
+
+using HealthChecks.UI.Client;
+
 using Lime.Protocol.Serialization.Newtonsoft;
 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
-using Take.Api.Security.Heimdall.Extensions;
 
 using Take.Api.Health.Eir.Extensions;
-using Microsoft.AspNetCore.Diagnostics.HealthChecks;
-using HealthChecks.UI.Client;
-using Microsoft.AspNetCore.Routing;
+using Take.Api.Security.Heimdall.Extensions;
 
 namespace Blip.Api.Template
 {
 
-    #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public class Startup
     {
         private const string SWAGGERFILE_PATH = "./swagger/v1/swagger.json";
@@ -125,7 +129,13 @@ namespace Blip.Api.Template
 
             endpoints.MapHealthChecks(HEALTH_CHECK_ENDPOINT, new HealthCheckOptions
             {
-                ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+                ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse,
+                ResultStatusCodes =
+                {
+                    [HealthStatus.Healthy] = StatusCodes.Status200OK,
+                    [HealthStatus.Degraded] = StatusCodes.Status503ServiceUnavailable,
+                    [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+                }
             });
         }
     }


### PR DESCRIPTION
These adjustments allow the use of health check with a more current version of _Take.Blip.Client_ and the definition of status for cases where some service is unavailable.