### PR TITLE
Fix deprecated extensions/v1beta1 ingress

### DIFF
--- a/content/Api/Blip.Api.Template/charts/blipapitemplate/templates/ingress.yaml
+++ b/content/Api/Blip.Api.Template/charts/blipapitemplate/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "blipapitemplate.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "blipapitemplate.fullname" . }}-{{ .Values.environment.stage }}
@@ -21,9 +21,13 @@ spec:
     - host: {{ .Values.ingress.hostName }}
       http:
         paths:
-          - backend:
-              serviceName: {{ template "blipapitemplate.fullname" . }}-{{ .Values.environment.stage }}
-              servicePort: http
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ template "blipapitemplate.fullname" . }}-{{ .Values.environment.stage }}
+                port:
+                  name: http
   tls: 
     - secretName: {{ .Values.ingress.tls.secretName }}
       hosts:


### PR DESCRIPTION
Due to an update in our cluster, the apiVersion `extensions/v1beta1` is deprecated, as seen [here](https://curupira.visualstudio.com/Takepedia/_wiki/wikis/Takepedia.wiki/4069/🚨-Erro-deploy-Ingress-extensions-v1beta1-Ingress).

This is my attempt at fixing it, I do need help testing it though.